### PR TITLE
fix run script to use npx for next command

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -67,7 +67,7 @@ timeout /t 2 /nobreak >nul
 start http://localhost:3001
 
 REM Start dev server
-next dev -p 3001
+npx next dev -p 3001
 
 echo.
 echo Next.js stopped.


### PR DESCRIPTION
The run.cmd script was calling 'next' directly, which isn't recognized as a command since it's not in PATH. Changed to 'npx next' to properly execute the locally installed Next.js package.
