### PR TITLE
[rust] Fixed all warning/errors in hash-server

### DIFF
--- a/hashengine/src/bin/server.rs
+++ b/hashengine/src/bin/server.rs
@@ -1,4 +1,4 @@
-use actix_web::{web, App, HttpResponse, HttpServer, middleware};
+use actix_web::{web, App, HttpResponse, HttpServer};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, RwLock};
 use rayon::prelude::*;
@@ -30,6 +30,7 @@ struct InitRequest {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct AshConfig {
     #[serde(rename = "nbLoops")]
     nb_loops: u32,
@@ -192,7 +193,7 @@ async fn hash_batch_handler(req: web::Json<BatchHashRequest>) -> HttpResponse {
         })
         .collect();
 
-    let hash_duration = hash_start.elapsed();
+    let _hash_duration = hash_start.elapsed();
     let total_duration = batch_start.elapsed();
     let throughput = (preimage_count as f64 / total_duration.as_secs_f64()) as u64;
 

--- a/hashengine/src/hashengine.rs
+++ b/hashengine/src/hashengine.rs
@@ -1,4 +1,4 @@
-use crate::rom::{RomGenerationType, Rom, RomDigest};
+use crate::rom::{Rom, RomDigest};
 
 
 use cryptoxide::{
@@ -7,11 +7,10 @@ use cryptoxide::{
 };
 
 // ** Consolidated Imports required for scavenge function **
-use std::sync::mpsc::{Sender, channel};
-use std::{sync::Arc, thread, time::SystemTime};
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 // use indicatif::{ProgressBar, ProgressStyle};
-use hex;
 // ************************************
 
 
@@ -130,8 +129,8 @@ impl VM {
         }
 
         let mut digests = init_buffer_digests.chunks(DIGEST_INIT_SIZE);
-        let prog_digest = Blake2b::<512>::new().update(&digests.next().unwrap());
-        let mem_digest = Blake2b::<512>::new().update(&digests.next().unwrap());
+        let prog_digest = Blake2b::<512>::new().update(digests.next().unwrap());
+        let mem_digest = Blake2b::<512>::new().update(digests.next().unwrap());
         let prog_seed = *<&[u8; 64]>::try_from(digests.next().unwrap()).unwrap();
 
         assert_eq!(digests.next(), None);
@@ -410,6 +409,7 @@ pub fn hash(salt: &[u8], rom: &Rom, nb_loops: u32, nb_instrs: u32) -> [u8; 64] {
     vm.finalize()
 }
 
+#[allow(dead_code)]
 pub fn hash_structure_good(hash: &[u8], zero_bits: usize) -> bool {
     let full_bytes = zero_bits / 8; // Number of full zero bytes
     let remaining_bits = zero_bits % 8; // Bits to check in the next byte
@@ -436,10 +436,12 @@ pub fn hash_structure_good(hash: &[u8], zero_bits: usize) -> bool {
 // SCAVENGE LOGIC
 // --------------------------------------------------------------------------
 
+#[allow(dead_code)]
 pub struct Thread {}
 
 // Structure to hold dynamic challenge parameters from the API
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct ChallengeParams {
     pub rom_key: String, // no_pre_mine hex string (used for ROM init)
     pub difficulty_mask: String, // difficulty hex string (used for submission check)
@@ -452,12 +454,14 @@ pub struct ChallengeParams {
 }
 
 #[derive(Clone)]
+#[allow(dead_code)]
 pub enum Result {
     Progress(usize),
     Found(u64), // We search for the 64-bit nonce value
 }
 
 // Helper to build the preimage string as specified in the API documentation
+#[allow(dead_code)]
 pub fn build_preimage(
     nonce: u64,
     address: &str,
@@ -480,6 +484,7 @@ pub fn build_preimage(
 }
 
 // Utility function to convert difficulty mask (e.g., "000FFFFF") to number of required zero bits
+#[allow(dead_code)]
 fn difficulty_to_zero_bits(difficulty_hex: &str) -> usize {
     let difficulty_bytes = hex::decode(difficulty_hex).unwrap();
     let mut zero_bits = 0;
@@ -495,6 +500,7 @@ fn difficulty_to_zero_bits(difficulty_hex: &str) -> usize {
 }
 
 // The worker thread function
+#[allow(dead_code)]
 fn spin(params: ChallengeParams, sender: Sender<Result>, stop_signal: Arc<AtomicBool>, start_nonce: u64, step_size: u64) {
     let mut nonce_value = start_nonce;
     const CHUNKS_SIZE: usize = 0xff;
@@ -523,10 +529,10 @@ fn spin(params: ChallengeParams, sender: Sender<Result>, stop_signal: Arc<Atomic
             return;
         }
 
-        if nonce_value & (CHUNKS_SIZE as u64) == 0 {
-            if sender.send(Result::Progress(CHUNKS_SIZE)).is_err() {
-                 return;
-            }
+        if nonce_value & (CHUNKS_SIZE as u64) == 0
+            && sender.send(Result::Progress(CHUNKS_SIZE)).is_err()
+        {
+            return;
         }
 
         // Increment nonce by the thread step size

--- a/hashengine/src/lib.rs
+++ b/hashengine/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 // Import HashEngine modules
 mod hashengine;
 mod rom;
@@ -22,8 +24,8 @@ static ROM_READY: Mutex<bool> = Mutex::new(false);
 #[napi]
 pub fn init_rom(
   no_pre_mine_hex: String,
-  nb_loops: u32,
-  nb_instrs: u32,
+  _nb_loops: u32,
+  _nb_instrs: u32,
   pre_size: u32,
   rom_size: u32,
   mixing_numbers: u32,

--- a/hashengine/src/rom.rs
+++ b/hashengine/src/rom.rs
@@ -6,6 +6,7 @@ use cryptoxide::{
 use std::{fmt, convert::TryInto};
 
 // function to help debug bytestrings
+#[allow(dead_code)]
 pub fn print_hex(name: &str, data: &[u8]) {
     print!("{}: ", name);
     for byte in data.iter() {
@@ -36,6 +37,7 @@ pub struct Rom {
 /// The generation type of the **ROM**.
 #[derive(Clone, Copy, Debug)]
 pub enum RomGenerationType {
+    #[allow(dead_code)]
     FullRandom,
     TwoStep {
         pre_size: usize,
@@ -46,6 +48,7 @@ pub enum RomGenerationType {
 // --- DEBUG STRUCT ---
 
 /// State required to generate the next chunk index and perform XOR mixing.
+#[allow(dead_code)]
 pub struct RomMixingState {
     pub mixing_buffer: Vec<u8>,
     pub offsets_bs: Vec<u8>,
@@ -101,7 +104,7 @@ impl Rom {
             .update(key)
             .finalize();
 
-        let digest = random_gen(gen_type, seed.try_into().unwrap(), &mut data);
+        let digest = random_gen(gen_type, seed, &mut data);
         Self { digest, data }
     }
 
@@ -180,6 +183,7 @@ fn random_gen(gen_type: RomGenerationType, seed: [u8; 32], output: &mut [u8]) ->
 // --- DEBUG FUNCTIONS EXPOSED FOR TESTING ---
 
 /// Runs setup logic and returns the initial state before the chunk loop starts.
+#[allow(dead_code)]
 pub fn new_debug(key: &[u8], gen_type: RomGenerationType, size: usize) -> RomMixingState {
     // 1. Run V0 seed logic
     let size_bytes = (size as u32).to_le_bytes();
@@ -195,7 +199,7 @@ pub fn new_debug(key: &[u8], gen_type: RomGenerationType, size: usize) -> RomMix
     };
 
     let mut mixing_buffer = vec![0; pre_size];
-    let seed: [u8; 32] = seed_raw.try_into().unwrap();
+    let seed: [u8; 32] = seed_raw;
     let data = vec![0; size];
     argon2::hprime(&mut mixing_buffer, &seed);
 
@@ -241,6 +245,7 @@ pub fn new_debug(key: &[u8], gen_type: RomGenerationType, size: usize) -> RomMix
 
 /// Generates the next chunk of ROM data using the current state and returns
 /// the resulting 64-byte mixed chunk. Does NOT update the final ROM data.
+#[allow(dead_code)]
 pub fn step_debug(state: &mut RomMixingState) -> [u8; DATASET_ACCESS_SIZE] {
     if state.steps_taken >= state.max_steps {
         panic!("Exceeded maximum mixing steps ({}) for ROM size.", state.max_steps);
@@ -294,6 +299,7 @@ pub fn step_debug(state: &mut RomMixingState) -> [u8; DATASET_ACCESS_SIZE] {
     actual_chunk
 }
 
+#[allow(dead_code)]
 pub fn build_rom_from_state(mut state: RomMixingState, size: usize) -> Rom {
     let mut rom_data_vec = Vec::with_capacity(size);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1101,6 +1101,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2013,6 +2014,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2058,6 +2060,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2067,6 +2070,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },


### PR DESCRIPTION
  src/hashengine.rs:
  - Removed unused imports: RomGenerationType, channel, thread, SystemTime
  - Removed redundant hex import
  - Fixed needless borrows on lines 133-134 (removed & from digests.next().unwrap())
  - Fixed collapsible if statement on lines 525-529
  - Added #[allow(dead_code)] to: hash_structure_good, Thread, ChallengeParams, Result, build_preimage, difficulty_to_zero_bits, and spin

  src/lib.rs:
  - Prefixed unused parameters with underscore: _nb_loops and _nb_instrs
  - Added #![allow(non_snake_case)] at the crate root to address the crate naming convention

  src/rom.rs:
  - Removed useless .try_into().unwrap() conversions on lines 104 and 198
  - Added #[allow(dead_code)] to: print_hex, FullRandom variant, RomMixingState, new_debug, step_debug, and build_rom_from_state

  src/bin/server.rs:
  - Removed unused middleware import
  - Prefixed unused variable with underscore: _hash_duration
  - Added #[allow(dead_code)] to AshConfig struct

  All changes compile successfully with no clippy errors!